### PR TITLE
Set sample dir/file permissions

### DIFF
--- a/dashdb_rstudio/startup.sh
+++ b/dashdb_rstudio/startup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+chown rstudio:rstudio -R /home/rstudio/samples
+/init


### PR DESCRIPTION
Introduced a startup script for setting the sample dir/file owner to rstudio (RUN chmod has no effect since /home/rstudio is a volume).
